### PR TITLE
Fix npm install error

### DIFF
--- a/src/graph/analyzer.ts
+++ b/src/graph/analyzer.ts
@@ -2,8 +2,8 @@
  * Analyze dependency graph and calculate critical paths
  */
 
-import { DependencyGraph, IssueNode } from '../api/types';
-import { GraphNode, CycleError } from './types';
+import { DependencyGraph } from '../api/types';
+import { CycleError } from './types';
 
 export class GraphAnalyzer {
   /**

--- a/src/parser/dependency-parser.ts
+++ b/src/parser/dependency-parser.ts
@@ -70,7 +70,7 @@ export class DependencyParser {
   private parsePatterns(
     text: string,
     patterns: DependencyPattern[],
-    type: 'sub-issue' | 'blocked-by'
+    _type: 'sub-issue' | 'blocked-by'
   ): Set<number> {
     const issueNumbers = new Set<number>();
 

--- a/src/visualizer/interactive.ts
+++ b/src/visualizer/interactive.ts
@@ -2,7 +2,7 @@
  * Generate interactive HTML visualization using Cytoscape.js
  */
 
-import { DependencyGraph, IssueNode } from '../api/types';
+import { DependencyGraph } from '../api/types';
 import { Formatter } from './formatter';
 
 export class InteractiveGenerator {


### PR DESCRIPTION
Remove unused imports and parameters that were causing npm install to fail:
- Remove unused IssueNode and GraphNode imports from analyzer.ts
- Prefix unused type parameter with underscore in dependency-parser.ts
- Remove unused IssueNode import from interactive.ts